### PR TITLE
Fix client id query param

### DIFF
--- a/www/app.py
+++ b/www/app.py
@@ -98,7 +98,7 @@ class HeartBeatManager():
 
     def read(self):
         """Look for our name on rovercode-web. Sets web_id if found."""
-        result = requests.get(ROVERCODE_WEB_REG_URL+'?client_id='+self.client_id, headers=self.auth_header)
+        result = requests.get(ROVERCODE_WEB_REG_URL+'?oauth_application__client_id='+self.client_id, headers=self.auth_header)
         try:
             info = json.loads(result.text)[0]
             self.web_id = info['id']

--- a/www/tests/test_app.py
+++ b/www/tests/test_app.py
@@ -74,7 +74,7 @@ def test_register_with_web_update(testapp):
                   json=response_payload, status=200,
                   content_type='application/json'
     )
-    url_re = re.compile(testapp.ROVERCODE_WEB_REG_URL + r'\?client_id=xxxx')
+    url_re = re.compile(testapp.ROVERCODE_WEB_REG_URL + r'\?oauth_application__client_id=xxxx')
     response_list = [response_payload]
     responses.add(responses.GET,
                   url_re,
@@ -96,6 +96,6 @@ def test_register_with_web_update(testapp):
     assert testapp.binary_sensors[1].pin == 'Pin-B'
     assert len(responses.calls) == 3
     assert responses.calls[0].request.url == testapp.ROVERCODE_WEB_OAUTH2_URL + '/'
-    assert responses.calls[1].request.url == testapp.ROVERCODE_WEB_REG_URL + '?client_id=xxxx'
+    assert responses.calls[1].request.url == testapp.ROVERCODE_WEB_REG_URL + '?oauth_application__client_id=xxxx'
     # test that the update happened
     assert responses.calls[2].request.url == testapp.ROVERCODE_WEB_REG_URL + '/' + str(web_id)+'/'


### PR DESCRIPTION
This fixes the oauth client_id query parameter in the request to the rovercode-web REST API. It corresponds with [this change](https://github.com/rovercode/rovercode-web/pull/131) on the rovercode-web side.