### PR TITLE
Add trailing slash to websocket endpoints

### DIFF
--- a/www/app.py
+++ b/www/app.py
@@ -150,7 +150,7 @@ def sensors_thread():
                 pass
             s.old_val = new_val
 
-@socketio.on('connect', namespace='/api/v1')
+@socketio.on('connect', namespace='/api/v1/')
 def connect():
     """Connect to the rovercode-web websocket."""
     global ws_thread
@@ -159,7 +159,7 @@ def connect():
         ws_thread = socketio.start_background_task(target=sensors_thread)
     emit('status', {'data': 'Connected'})
 
-@socketio.on('status', namespace='/api/v1')
+@socketio.on('status', namespace='/api/v1/')
 def test_message(message):
     """Send a debug test message when status is received from rovercode-web."""
     print "Got a status message: " + message['data']


### PR DESCRIPTION
The websocket enpoints (namespaces) were `/api/v1`, but the Mission Control javascript was looking for `/api/v1/`, so they weren't working at all.

I'm pretty sure we want the trailing slash, right? If not, let me know, and we can make the opposite change on Mission Control.