### PR TITLE
Use system site packages in test virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ script:
 after_success:
   - coveralls
 language: python
+virtualenv:
+  - system_site_packages: true
 python:
 - "2.7"
 notifications:


### PR DESCRIPTION
Travis CI uses a virtualenv for running the tests. The virtualenv needs to be created with `--system-site-packages` to access `python-smbus`.