### PR TITLE
Skip sensor if values cannot be read

### DIFF
--- a/www/app.py
+++ b/www/app.py
@@ -145,7 +145,11 @@ def sensors_thread():
         global binary_sensors
         socketio.sleep(0.3)
         for s in binary_sensors:
-            new_val = s.sensor.is_high()
+            try:
+                new_val = s.sensor.is_high()
+            except IOError:
+                # Skip it and try again later
+                continue
             if (s.old_val == False) and (new_val == True):
                 print s.rising_event
                 socketio.emit('binary_sensors', {'data': s.rising_event},

--- a/www/drivers/VCNL4010.py
+++ b/www/drivers/VCNL4010.py
@@ -65,6 +65,7 @@ class VCNL4010:
         except IOError:
             print 'Failed to read VCNL4010 at address {} register 0x85'\
                 .format(self.i2c_addr)
+            raise
 
         # Convert the data
         luminance = data[0] * 256 + data[1]  # lux

--- a/www/tests/drivers/test_VCNL4010.py
+++ b/www/tests/drivers/test_VCNL4010.py
@@ -1,5 +1,6 @@
 """Test the VCNL4010 sensor helper."""
 from mock import patch, call, MagicMock
+import pytest
 
 from drivers.VCNL4010 import VCNL4010
 
@@ -31,8 +32,18 @@ def test_get_is_high():
         # value equal to threshold doesn't really concern us
 
 
+def test_get_is_high_error():
+    """Test the binary interpretation of the proximity value with an error."""
+    mockbus = MagicMock()
+    with patch('smbus.SMBus', return_value=mockbus):
+        driver = VCNL4010(1, 2, 3, 258)
+        mockbus.read_i2c_block_data.side_effect = IOError()
+        with pytest.raises(IOError):
+            driver.is_high()
+
+
 def test_get_values():
-    """Test the binary interpretation of the proximity value."""
+    """Test getting the values from the sensor."""
     mockbus = MagicMock()
     with patch('smbus.SMBus', return_value=mockbus):
         driver = VCNL4010(1, 2, 3, 258)


### PR DESCRIPTION
Fixes #136 

If there is an error getting sensor values, just skip that sensor and continue.