### PR TITLE
Change docs theme to alabaster

### DIFF
--- a/www/docs/conf.py
+++ b/www/docs/conf.py
@@ -92,7 +92,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = 'alabaster'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
How about we change from the default rtd docs theme to alabaster (the flask-looking theme)? It's pretty subjective, but I like reading alabaster because of the narrower text column.

It's a built-in sphinx theme, so I think that means read-the-docs will have it available.