### PR TITLE
Configure docker build to not require .env in image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ script:
 - pushd rovercode
 - python -m pytest
 - prospector
-- popd
 after_success:
 - coveralls
 language: python

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ MAINTAINER Clifton Barnes <clifton.barnes@rovercode.com>
 RUN apt-get update
 RUN apt-get install -y build-essential python3-dev libi2c-dev python3-smbus
 
-ADD .env /var/rovercode/.env
 ADD pytest.ini /var/rovercode/pytest.ini
 ADD requirements.txt /var/rovercode/requirements.txt
 ADD GrovePi /var/rovercode/GrovePi

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ # create your .env, as described in the section below
 $ sudo apt install git docker.io
 $ git clone --recursive https://github.com/rovercode/rovercode.git && cd rovercode
 $ sudo docker build -t rovercode .
-$ sudo docker run --name rovercode -v $PWD:/var/www/rovercode -p 80:80 -d rovercode
+$ sudo docker run --name rovercode -v $PWD:/var/rovercode -p 80:80 -d rovercode
 
 ```
 Then, still on your development PC, head to rovercode.com and connect to your "rover" (your PC running the service).

--- a/rovercode/app.py
+++ b/rovercode/app.py
@@ -127,7 +127,7 @@ def run_service(run_forever=True, use_dotenv=True):
     LOGGER.info("Starting the Rovercode service!")
     if use_dotenv:  # pragma: no cover
         load_dotenv('../.env')
-    rovercode_web_host = os.getenv("ROVERCODE_WEB_HOST", "rovercode.com")
+    rovercode_web_host = os.getenv("ROVERCODE_WEB_HOST", "app.rovercode.com")
 
     rovercode_web_host_secure = \
         os.getenv("ROVERCODE_WEB_HOST_SECURE", 'True').lower() == 'true'


### PR DESCRIPTION
This will allow for building the docker image without the rover configuration. The configuration will then be mapped in when the container is started.