### PR TITLE
Go back to top directory for deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
 - prospector
 after_success:
 - coveralls
+- popd
 language: python
 python:
 - '3.6'


### PR DESCRIPTION
The deploy failed with the previous change because it could no longer access `docs/` which is at the top level directory