### PR TITLE
GrovePi Chainable RGB LED support

### DIFF
--- a/docs/example-rover-config.rst
+++ b/docs/example-rover-config.rst
@@ -12,5 +12,7 @@ get from the server.
         "left-ultrasonic-port": 1,
         "right-ultrasonic-port": 2,
         "left-ultrasonic-threshold": 10,
-        "right-ultrasonic-threshold": 10
+        "right-ultrasonic-threshold": 10,
+		"status-rgb-led-port": 7,
+		"num-user-rgb-leds": 2
     }

--- a/docs/example-rover-config.rst
+++ b/docs/example-rover-config.rst
@@ -13,6 +13,6 @@ get from the server.
         "right-ultrasonic-port": 2,
         "left-ultrasonic-threshold": 10,
         "right-ultrasonic-threshold": 10,
-		"status-rgb-led-port": 7,
-		"num-user-rgb-leds": 2
+        "chainable-rgb-led-port": 7,
+        "num-chainable-rgb-leds": 2
     }

--- a/docs/example-rover-config.rst
+++ b/docs/example-rover-config.rst
@@ -7,8 +7,6 @@ get from the server.
 .. code-block:: json
 
     {
-        "left-motor-port": "A",
-        "right-motor-port": "B",
         "left-ultrasonic-port": 1,
         "right-ultrasonic-port": 2,
         "left-ultrasonic-threshold": 10,

--- a/docs/websocket-protocol.rst
+++ b/docs/websocket-protocol.rst
@@ -22,6 +22,20 @@ Motor Commands
        "unit": "percent"
     }
 
+LED Commands
+-----------------
+
+.. code-block:: json
+
+    {
+       "type": "chainable-rgb-led-command",
+       "led-id": 0,
+       "red-value": 84,
+       "green-value": 255,
+       "blue-value": 0,
+    }
+
+
 Sensor Readings
 ----------------
 

--- a/rovercode/.prospector.yaml
+++ b/rovercode/.prospector.yaml
@@ -10,9 +10,14 @@ pylint:
     - R0903
     # Using the global statement
     - global-statement
+    # I like fstrings
+    - logging-fstring-interpolation
 
 pep8:
   full: true
+  disable:
+    # bare except already covered in pylint
+    - E722
 
 pep257:
   run: true

--- a/rovercode/app.py
+++ b/rovercode/app.py
@@ -6,7 +6,7 @@ import json
 import os
 
 from dotenv import load_dotenv
-import websocket
+from websocket import WebSocketApp
 from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
 
@@ -82,6 +82,10 @@ def on_message(_, raw_message):
             message.get(constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD)
         if led_id > CHAINABLE_RGB_MANAGER.count - 1:
             LOGGER.warning(f'Invalid led {led_id}')
+            return
+        if None in (red_value, green_value, blue_value):
+            LOGGER.warning('Missing color value')
+            return
         CHAINABLE_RGB_MANAGER.set_color(led_id, red_value,
                                         green_value, blue_value)
 
@@ -196,7 +200,7 @@ def run_service(run_forever=True, use_dotenv=True):
         ws_url = "{}://{}/ws/realtime/{}/".format(
             "wss" if web_host_secure else "ws", host, CLIENT_ID)
         auth_string = "Authorization: Bearer {}".format(SESSION.access_token)
-        ws_connection = websocket.WebSocketApp(
+        ws_connection = WebSocketApp(
             ws_url,
             on_message=on_message,
             on_error=on_error,

--- a/rovercode/app.py
+++ b/rovercode/app.py
@@ -75,19 +75,11 @@ def on_message(_, raw_message):
                                    message[constants.MOTOR_VALUE_FIELD],
                                    message[constants.MOTOR_DIRECTION_FIELD])
     elif message_type == constants.CHAINABLE_RGB_LED_COMMAND:
-        led_id, red_value, green_value, blue_value = \
-            message.get(constants.CHAINABLE_RGB_LED_ID_FIELD), \
-            message.get(constants.CHAINABLE_RGB_LED_RED_VALUE_FIELD), \
-            message.get(constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD), \
-            message.get(constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD)
-        if led_id > CHAINABLE_RGB_MANAGER.count - 1:
-            LOGGER.warning(f'Invalid led {led_id}')
-            return
-        if None in (red_value, green_value, blue_value):
-            LOGGER.warning('Missing color value')
-            return
-        CHAINABLE_RGB_MANAGER.set_color(led_id, red_value,
-                                        green_value, blue_value)
+        CHAINABLE_RGB_MANAGER.set_color(
+            message.get(constants.CHAINABLE_RGB_LED_ID_FIELD),
+            message.get(constants.CHAINABLE_RGB_LED_RED_VALUE_FIELD),
+            message.get(constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD),
+            message.get(constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD))
 
 
 def on_error(_, error):  # pragma: no cover

--- a/rovercode/app.py
+++ b/rovercode/app.py
@@ -14,6 +14,7 @@ import constants
 from motor_controller import MotorController
 from chainable_rgb_leds_manager import ChainableRgbLedsManager
 from drivers.grove_motors import GroveMotors
+from drivers.grovepi_chainable_rgb_leds import GrovePiChainableRgbLeds
 from input_utils import init_inputs
 
 logging.basicConfig()
@@ -22,7 +23,9 @@ LOGGER.setLevel(logging.getLevelName('INFO'))
 
 # Globals
 ROVERCODE_WEB_URL = None
+ROVER_CONFIG = None
 MOTOR_CONTROLLER = None
+CHAINABLE_RGB_MANAGER = None
 CLIENT_ID = None
 SESSION = None
 
@@ -60,6 +63,7 @@ def poll_sensors(ws_connection, binary_sensors, run_once_only=False):
 def on_message(_, raw_message):
     """Handle incoming websocket message."""
     global MOTOR_CONTROLLER
+    global CHAINABLE_RGB_MANAGER
     message = json.loads(raw_message)
     message_type = message[constants.MESSAGE_TYPE]
     if message_type == constants.MOTOR_COMMAND:
@@ -71,7 +75,16 @@ def on_message(_, raw_message):
                                    message[constants.MOTOR_VALUE_FIELD],
                                    message[constants.MOTOR_DIRECTION_FIELD])
     elif message_type == constants.CHAINABLE_RGB_LED_COMMAND:
-        LOGGER.info("DUDE. Got an LED command.")
+        led_id, red_value, green_value, blue_value = \
+            message.get(constants.CHAINABLE_RGB_LED_ID_FIELD), \
+            message.get(constants.CHAINABLE_RGB_LED_RED_VALUE_FIELD), \
+            message.get(constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD), \
+            message.get(constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD)
+        if led_id > CHAINABLE_RGB_MANAGER.count - 1:
+            LOGGER.warning(f'Invalid led {led_id}')
+        CHAINABLE_RGB_MANAGER.set_color(led_id, red_value, green_value, blue_value)
+    else:
+        LOGGER.warning(f'Received unknown message type {message_type}')
 
 
 def on_error(_, error):  # pragma: no cover
@@ -86,19 +99,8 @@ def on_close(_):  # pragma: no cover
 
 def on_open(ws_connection):
     """Start up threads upon opening websocket connections."""
-    global SESSION
-    global MOTOR_CONTROLLER
-    global ROVERCODE_WEB_URL
-    global CLIENT_ID
-
-    info = json.loads(SESSION.get('{}/api/v1/rovers?CLIENT_ID={}'.format(
-        ROVERCODE_WEB_URL, CLIENT_ID)).text)['results'][0]
-    LOGGER.info("Found myself - I am %s, with id %s",
-                info[constants.ROVER_NAME], info[constants.ROVER_ID])
-    rover_config = info[constants.ROVER_CONFIG]
-
-    # Create motor manager
-    MOTOR_CONTROLLER = MotorController(GroveMotors())
+    global CHAINABLE_RGB_MANAGER
+    global ROVER_CONFIG
 
     # Start heartbeat thread
     thread = Thread(target=send_heartbeat, args=(ws_connection,))
@@ -106,17 +108,23 @@ def on_open(ws_connection):
     LOGGER.info("Heartbeat thread started")
 
     # Start inputs thread
-    binary_sensors = init_inputs(rover_config)
+    binary_sensors = init_inputs(ROVER_CONFIG)
     thread = Thread(target=poll_sensors, args=(ws_connection, binary_sensors))
     thread.start()
     LOGGER.info("Sensors thread started")
+
+    # Set LEDs to "OK" blue
+    CHAINABLE_RGB_MANAGER.set_all_led_colors(*constants.RGB_BLUE)
+
 
 
 def run_service(run_forever=True, use_dotenv=True):
     """Kick off the service."""
     global SESSION
     global MOTOR_CONTROLLER
+    global CHAINABLE_RGB_MANAGER
     global ROVERCODE_WEB_URL
+    global ROVER_CONFIG
     global CLIENT_ID
     LOGGER.info("Starting the Rovercode service!")
     if use_dotenv:  # pragma: no cover
@@ -150,20 +158,49 @@ def run_service(run_forever=True, use_dotenv=True):
                         CLIENT_ID=CLIENT_ID,
                         client_secret=client_secret)
 
-    ws_url = "{}://{}/ws/realtime/{}/".format(
-        "wss" if rovercode_web_host_secure else "ws",
-        rovercode_web_host,
-        CLIENT_ID)
-    auth_string = "Authorization: Bearer {}".format(SESSION.access_token)
-    ws_connection = websocket.WebSocketApp(
-        ws_url,
-        on_message=on_message,
-        on_error=on_error,
-        on_close=on_close,
-        header=[auth_string])
-    ws_connection.on_open = on_open
-    if run_forever:  # pragma: no cover
-        ws_connection.run_forever()
+    # Get rover config info from server
+    info = json.loads(SESSION.get('{}/api/v1/rovers?CLIENT_ID={}'.format(
+        ROVERCODE_WEB_URL, CLIENT_ID)).text)['results'][0]
+    LOGGER.info("Found myself - I am %s, with id %s",
+                info[constants.ROVER_NAME], info[constants.ROVER_ID])
+    ROVER_CONFIG = info[constants.ROVER_CONFIG]
+
+    # Create chainable RGB LED manager
+    chainable_rgb_led_count, chainable_rgb_led_port = \
+        ROVER_CONFIG.get(constants.NUM_CHAINABLE_RGB_LEDS), \
+        ROVER_CONFIG.get(constants.CHAINABLE_RGB_LED_PORT)
+    if chainable_rgb_led_count is None:
+        LOGGER.error(f'{constants.NUM_CHAINABLE_RGB_LEDS} missing from config')
+    if chainable_rgb_led_port is None:
+        LOGGER.error(f'{constants.CHAINABLE_RGB_LED_PORT} missing from config')
+    CHAINABLE_RGB_MANAGER = ChainableRgbLedsManager(chainable_rgb_led_port,
+                                                    chainable_rgb_led_count,
+                                                    GrovePiChainableRgbLeds())
+
+    # Create motor manager
+    try:
+        MOTOR_CONTROLLER = MotorController(GroveMotors())
+    except:
+        CHAINABLE_RGB_MANAGER.set_all_led_colors(*constants.RGB_RED)
+
+    # Create websocket connection
+    try:
+        ws_url = "{}://{}/ws/realtime/{}/".format(
+            "wss" if rovercode_web_host_secure else "ws",
+            rovercode_web_host,
+            CLIENT_ID)
+        auth_string = "Authorization: Bearer {}".format(SESSION.access_token)
+        ws_connection = websocket.WebSocketApp(
+            ws_url,
+            on_message=on_message,
+            on_error=on_error,
+            on_close=on_close,
+            header=[auth_string])
+        ws_connection.on_open = on_open
+        if run_forever:  # pragma: no cover
+            ws_connection.run_forever()
+    except:
+        CHAINABLE_RGB_MANAGER.set_all_led_colors(*constants.RGB_YELLOW)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/rovercode/app.py
+++ b/rovercode/app.py
@@ -83,8 +83,6 @@ def on_message(_, raw_message):
         if led_id > CHAINABLE_RGB_MANAGER.count - 1:
             LOGGER.warning(f'Invalid led {led_id}')
         CHAINABLE_RGB_MANAGER.set_color(led_id, red_value, green_value, blue_value)
-    else:
-        LOGGER.warning(f'Received unknown message type {message_type}')
 
 
 def on_error(_, error):  # pragma: no cover
@@ -171,8 +169,10 @@ def run_service(run_forever=True, use_dotenv=True):
         ROVER_CONFIG.get(constants.CHAINABLE_RGB_LED_PORT)
     if chainable_rgb_led_count is None:
         LOGGER.error(f'{constants.NUM_CHAINABLE_RGB_LEDS} missing from config')
+        return
     if chainable_rgb_led_port is None:
         LOGGER.error(f'{constants.CHAINABLE_RGB_LED_PORT} missing from config')
+        return
     CHAINABLE_RGB_MANAGER = ChainableRgbLedsManager(chainable_rgb_led_port,
                                                     chainable_rgb_led_count,
                                                     GrovePiChainableRgbLeds())

--- a/rovercode/app.py
+++ b/rovercode/app.py
@@ -12,6 +12,7 @@ from requests_oauthlib import OAuth2Session
 
 import constants
 from motor_controller import MotorController
+from chainable_rgb_leds_manager import ChainableRgbLedsManager
 from drivers.grove_motors import GroveMotors
 from input_utils import init_inputs
 
@@ -69,6 +70,8 @@ def on_message(_, raw_message):
         MOTOR_CONTROLLER.set_speed(message[constants.MOTOR_ID_FIELD],
                                    message[constants.MOTOR_VALUE_FIELD],
                                    message[constants.MOTOR_DIRECTION_FIELD])
+    elif message_type == constants.CHAINABLE_RGB_LED_COMMAND:
+        LOGGER.info("DUDE. Got an LED command.")
 
 
 def on_error(_, error):  # pragma: no cover

--- a/rovercode/app.py
+++ b/rovercode/app.py
@@ -75,11 +75,15 @@ def on_message(_, raw_message):
                                    message[constants.MOTOR_VALUE_FIELD],
                                    message[constants.MOTOR_DIRECTION_FIELD])
     elif message_type == constants.CHAINABLE_RGB_LED_COMMAND:
-        CHAINABLE_RGB_MANAGER.set_color(
-            message.get(constants.CHAINABLE_RGB_LED_ID_FIELD),
-            message.get(constants.CHAINABLE_RGB_LED_RED_VALUE_FIELD),
-            message.get(constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD),
-            message.get(constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD))
+        try:
+            CHAINABLE_RGB_MANAGER.set_led_color(
+                message.get(constants.CHAINABLE_RGB_LED_ID_FIELD),
+                message.get(constants.CHAINABLE_RGB_LED_RED_VALUE_FIELD),
+                message.get(constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD),
+                message.get(constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD))
+        except ValueError as exception:
+            LOGGER.error(f'Unable to set LED color: {exception}')
+            return
 
 
 def on_error(_, error):  # pragma: no cover

--- a/rovercode/chainable_rgb_leds_manager.py
+++ b/rovercode/chainable_rgb_leds_manager.py
@@ -1,0 +1,46 @@
+"""Class for managing the motor state."""
+
+import logging
+from constants import \
+    LEFT_MOTOR, RIGHT_MOTOR,\
+    MOTOR_DIRECTION_FORWARD, MOTOR_DIRECTION_BACKWARD
+logging.basicConfig()
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.getLevelName('INFO'))
+
+
+class ChainableRgbLedsManager:
+    """Object to manage RGB LEDs."""
+
+    def __init__(self, port, user_led_count, driver):
+        """Construct a RgbLedManager.
+
+        Keeps track of one status LED and a configurable number of
+        user-settable LEDs.
+        """
+        self.port = port
+        self.count = 1 + user_led_count
+        self.driver = driver
+        self.driver.setup(port, self.count)
+        LOGGER.info("RGB LED manager initialized")
+
+    def set_status_led_color(self, r, g, b):
+        self.set_led_color(0, r, g, b)
+
+    def set_user_led_color(self, user_led, r, g, b):
+        self.set_led_color(user_led + 1, r, g, b)
+
+    def set_led_color(self, led, r, g, b):
+        """Set the speed of a motor pin."""
+        if led > self.count - 1:
+            LOGGER.error("Unknown led %s", led)
+            return
+
+        for component in (r, g, b):
+            if not 0 <= component <= 255:
+                LOGGER.error("RGB color value %s not in range 0-255.")
+                return
+
+        LOGGER.info("Setting LED %s to %s, %s, %s.",
+                    led, r, g, b)
+        self.driver.set_rgb(led, r, g, b)

--- a/rovercode/chainable_rgb_leds_manager.py
+++ b/rovercode/chainable_rgb_leds_manager.py
@@ -9,24 +9,16 @@ LOGGER.setLevel(logging.getLevelName('INFO'))
 class ChainableRgbLedsManager:
     """Object to manage RGB LEDs."""
 
-    def __init__(self, port, user_led_count, driver):
+    def __init__(self, port, count, driver):
         """Construct a RgbLedManager."""
         self.port = port
-        self.count = 1 + user_led_count
+        self.count = count
         self.driver = driver
         self.driver.setup(port, self.count)
         LOGGER.info("RGB LED manager initialized")
 
-    def set_status_led_color(self, red, green, blue):
-        """Set status LED color."""
-        self.set_led_color(0, red, green, blue)
-
-    def set_user_led_color(self, user_led, red, green, blue):
-        """Set user LED color."""
-        self.set_led_color(user_led + 1, red, green, blue)
-
     def set_led_color(self, led, red, green, blue):
-        """Set the speed of a motor pin."""
+        """Set LED color."""
         if led > self.count - 1:
             LOGGER.error("Unknown led %s", led)
             return

--- a/rovercode/chainable_rgb_leds_manager.py
+++ b/rovercode/chainable_rgb_leds_manager.py
@@ -31,8 +31,7 @@ class ChainableRgbLedsManager:
         for component in (red, green, blue):
             if component not in component_range:
                 raise ValueError(f'RGB value {component} not in range '
-                                 f'{component_range[0]}-'
-                                 f'{component_range[1]-1}')
+                                 f'{component_range[0]}-{component_range[-1]}')
 
         LOGGER.info("Setting LED %s to %s, %s, %s.",
                     led, red, green, blue)

--- a/rovercode/chainable_rgb_leds_manager.py
+++ b/rovercode/chainable_rgb_leds_manager.py
@@ -18,6 +18,7 @@ class ChainableRgbLedsManager:
         LOGGER.info("RGB LED manager initialized")
 
     def set_all_led_colors(self, red, green, blue):
+        """Set all LEDs to the same color."""
         for led in range(self.count):
             self.set_led_color(led, red, green, blue)
 
@@ -34,4 +35,4 @@ class ChainableRgbLedsManager:
 
         LOGGER.info("Setting LED %s to %s, %s, %s.",
                     led, red, green, blue)
-        self.driver.set_rgb(led, red, green, blue)
+        self.driver.set_color(led, red, green, blue)

--- a/rovercode/chainable_rgb_leds_manager.py
+++ b/rovercode/chainable_rgb_leds_manager.py
@@ -17,6 +17,10 @@ class ChainableRgbLedsManager:
         self.driver.setup(port, self.count)
         LOGGER.info("RGB LED manager initialized")
 
+    def set_all_led_colors(self, red, green, blue):
+        for led in range(self.count):
+            self.set_led_color(led, red, green, blue)
+
     def set_led_color(self, led, red, green, blue):
         """Set LED color."""
         if led > self.count - 1:

--- a/rovercode/chainable_rgb_leds_manager.py
+++ b/rovercode/chainable_rgb_leds_manager.py
@@ -1,9 +1,6 @@
 """Class for managing the motor state."""
 
 import logging
-from constants import \
-    LEFT_MOTOR, RIGHT_MOTOR,\
-    MOTOR_DIRECTION_FORWARD, MOTOR_DIRECTION_BACKWARD
 logging.basicConfig()
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.getLevelName('INFO'))
@@ -13,34 +10,32 @@ class ChainableRgbLedsManager:
     """Object to manage RGB LEDs."""
 
     def __init__(self, port, user_led_count, driver):
-        """Construct a RgbLedManager.
-
-        Keeps track of one status LED and a configurable number of
-        user-settable LEDs.
-        """
+        """Construct a RgbLedManager."""
         self.port = port
         self.count = 1 + user_led_count
         self.driver = driver
         self.driver.setup(port, self.count)
         LOGGER.info("RGB LED manager initialized")
 
-    def set_status_led_color(self, r, g, b):
-        self.set_led_color(0, r, g, b)
+    def set_status_led_color(self, red, green, blue):
+        """Set status LED color."""
+        self.set_led_color(0, red, green, blue)
 
-    def set_user_led_color(self, user_led, r, g, b):
-        self.set_led_color(user_led + 1, r, g, b)
+    def set_user_led_color(self, user_led, red, green, blue):
+        """Set user LED color."""
+        self.set_led_color(user_led + 1, red, green, blue)
 
-    def set_led_color(self, led, r, g, b):
+    def set_led_color(self, led, red, green, blue):
         """Set the speed of a motor pin."""
         if led > self.count - 1:
             LOGGER.error("Unknown led %s", led)
             return
 
-        for component in (r, g, b):
+        for component in (red, green, blue):
             if not 0 <= component <= 255:
                 LOGGER.error("RGB color value %s not in range 0-255.")
                 return
 
         LOGGER.info("Setting LED %s to %s, %s, %s.",
-                    led, r, g, b)
-        self.driver.set_rgb(led, r, g, b)
+                    led, red, green, blue)
+        self.driver.set_rgb(led, red, green, blue)

--- a/rovercode/chainable_rgb_leds_manager.py
+++ b/rovercode/chainable_rgb_leds_manager.py
@@ -1,4 +1,4 @@
-"""Class for managing the motor state."""
+"""Class for managing the chainable RGB LEDs."""
 
 import logging
 logging.basicConfig()
@@ -24,13 +24,15 @@ class ChainableRgbLedsManager:
 
     def set_led_color(self, led, red, green, blue):
         """Set LED color."""
-        if led > self.count - 1:
+        if led not in range(self.count):
             LOGGER.error("Unknown led %s", led)
             return
 
+        component_range = self.driver.COMPONENT_RANGE
         for component in (red, green, blue):
-            if not 0 <= component <= 255:
-                LOGGER.error("RGB color value %s not in range 0-255.")
+            if component not in component_range:
+                LOGGER.error(f'RGB value {component} not in range '
+                             f'{component_range[0]}-{component_range[1]-1}.')
                 return
 
         LOGGER.info("Setting LED %s to %s, %s, %s.",

--- a/rovercode/chainable_rgb_leds_manager.py
+++ b/rovercode/chainable_rgb_leds_manager.py
@@ -25,15 +25,14 @@ class ChainableRgbLedsManager:
     def set_led_color(self, led, red, green, blue):
         """Set LED color."""
         if led not in range(self.count):
-            LOGGER.error("Unknown led %s", led)
-            return
+            raise ValueError(f'Unknown led {led}')
 
         component_range = self.driver.COMPONENT_RANGE
         for component in (red, green, blue):
             if component not in component_range:
-                LOGGER.error(f'RGB value {component} not in range '
-                             f'{component_range[0]}-{component_range[1]-1}.')
-                return
+                raise ValueError(f'RGB value {component} not in range '
+                                 f'{component_range[0]}-'
+                                 f'{component_range[1]-1}')
 
         LOGGER.info("Setting LED %s to %s, %s, %s.",
                     led, red, green, blue)

--- a/rovercode/constants.py
+++ b/rovercode/constants.py
@@ -15,7 +15,12 @@ MOTOR_DIRECTION_BACKWARD = 'backward'
 LEFT_MOTOR = 'motor-left'
 RIGHT_MOTOR = 'motor-right'
 MOTOR_IDS = (LEFT_MOTOR, RIGHT_MOTOR)
+
 CHAINABLE_RGB_LED_COMMAND = 'chainable-rgb-led-command'
+CHAINABLE_RGB_LED_ID_FIELD = 'led-id'
+CHAINABLE_RGB_LED_RED_VALUE_FIELD = 'red-value'
+CHAINABLE_RGB_LED_GREEN_VALUE_FIELD = 'green-value'
+CHAINABLE_RGB_LED_BLUE_VALUE_FIELD = 'blue-value'
 
 SENSOR_READING_TYPE = 'sensor-reading'
 SENSOR_ID_FIELD = 'sensor-id'
@@ -31,8 +36,15 @@ LEFT_ULTRASONIC_PORT = 'left-ultrasonic-port'
 LEFT_ULTRASONIC_THRESHOLD = 'left-ultrasonic-threshold'
 RIGHT_ULTRASONIC_PORT = 'right-ultrasonic-port'
 RIGHT_ULTRASONIC_THRESHOLD = 'right-ultrasonic-threshold'
+CHAINABLE_RGB_LED_PORT = 'chainable-rgb-led-port'
+NUM_CHAINABLE_RGB_LEDS = 'num-chainable-rgb-leds'
 
 # API constants
 ROVER_NAME = 'name'
 ROVER_ID = 'id'
 ROVER_CONFIG = 'config'
+
+# RGB colors
+RGB_BLUE = (0, 74, 255)
+RGB_RED = (255, 0, 0)
+RGB_YELLOW = (255, 255, 0)

--- a/rovercode/constants.py
+++ b/rovercode/constants.py
@@ -15,6 +15,7 @@ MOTOR_DIRECTION_BACKWARD = 'backward'
 LEFT_MOTOR = 'motor-left'
 RIGHT_MOTOR = 'motor-right'
 MOTOR_IDS = (LEFT_MOTOR, RIGHT_MOTOR)
+CHAINABLE_RGB_LED_COMMAND = 'chainable-rgb-led-command'
 
 SENSOR_READING_TYPE = 'sensor-reading'
 SENSOR_ID_FIELD = 'sensor-id'

--- a/rovercode/drivers/dummy_grovepi_interface.py
+++ b/rovercode/drivers/dummy_grovepi_interface.py
@@ -32,3 +32,19 @@ class MiniMotorDriver:  # noqa
 def ultrasonicRead(port):  # noqa
     """Read from the dummy ultrasonic sensor."""
     return 0
+
+
+def chainableRgbLed_pattern(pin, type, led):  # noqa
+    pass
+
+
+def storeColor(r, g, b):  # noqa
+    pass
+
+
+def chainableRgbLed_init(port, count):  # noqa
+    pass
+
+
+def pinMode(port, mode):  # noqa
+    pass

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -40,10 +40,9 @@ class GrovePiChainableRgbLeds:
 
         for component in (red, green, blue):
             if component not in self.COMPONENT_RANGE:
-                LOGGER.error(f'RGB color value %s not in range '
-                             f'{self.COMPONENT_RANGE[0]}-'
-                             f'{self.COMPONENT_RANGE[1]-1}.')
-                return
+                raise ValueError(f'RGB color value %s not in range '
+                                 f'{self.COMPONENT_RANGE[0]}-'
+                                 f'{self.COMPONENT_RANGE[1]-1}.')
         storeColor(red, green, blue)
         time.sleep(.1)
         chainableRgbLed_pattern(self.port, self.MODE_THIS_LED_ONLY, led)

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -1,8 +1,4 @@
-"""
-Class for communicating with the GrovePi ultrasonic ranger.
-
-Here we treat it as a binary sensor.
-"""
+"""Class for communicating with a GrovePi chainable RGB LED."""
 
 import os
 import logging
@@ -24,6 +20,8 @@ class GrovePiChainableRgbLeds:
     """A module to set the GrovePi Chainable RGB LEDs."""
 
     MODE_THIS_LED_ONLY = 0
+    COMPONENT_RANGE = 0, 256
+
     port = None
 
     def setup(self, port, count):
@@ -36,13 +34,15 @@ class GrovePiChainableRgbLeds:
                     count, port)
 
     def set_color(self, led, red, green, blue):
-        """Set color in RGB, each ranged 0-255."""
+        """Set color in RGB"""
         if self.port is None:
             raise RuntimeError("Must call setup before setting color.")
 
         for component in (red, green, blue):
-            if not 0 <= component <= 255:
-                LOGGER.error("RGB color value %s not in range 0-255.")
+            if component not in self.COMPONENT_RANGE:
+                LOGGER.error(f'RGB color value %s not in range '
+                             f'{self.COMPONENT_RANGE[0]}-'
+                             f'{self.COMPONENT_RANGE[1]-1}.')
                 return
         storeColor(red, green, blue)
         time.sleep(.1)

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -4,18 +4,19 @@ Class for communicating with the GrovePi ultrasonic ranger.
 Here we treat it as a binary sensor.
 """
 
+import os
 import logging
 import time
 
 logging.basicConfig()
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.getLevelName('INFO'))
-try:
-    from GrovePi.Software.Python.grovepi import chainableRgbLed_pattern,\
+if os.getenv('DEVELOPMENT', 'false').lower() == 'true':
+    LOGGER.warning("In DEVELOPMENT mode. Using dummy.")
+    from drivers.dummy_grovepi_interface import chainableRgbLed_pattern, \
         storeColor, chainableRgbLed_init, pinMode
-except ImportError:
-    LOGGER.warning("GrovePi lib unavailable. Using dummy.")
-    from drivers.dummy_grovepi_interface import chainableRgbLed_pattern,\
+else:
+    from grovepi import chainableRgbLed_pattern, \
         storeColor, chainableRgbLed_init, pinMode
 
 

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -31,18 +31,19 @@ class GrovePiChainableRgbLeds:
         pinMode(port, "OUTPUT")
         time.sleep(1)
         chainableRgbLed_init(self.port, count)
-        LOGGER.info("Setting up %s GrovePi Chainable RGB LEDs on port %s", count, port)
+        LOGGER.info("Setting up %s GrovePi Chainable RGB LEDs on port %s",
+                    count, port)
 
-    def set_color(self, led, r, g, b):
-        """Set color in RGB, each ranged 0-255"""
+    def set_color(self, led, red, green, blue):
+        """Set color in RGB, each ranged 0-255."""
         if self.port is None:
             raise RuntimeError("Must call setup before setting color.")
 
-        for component in (r, g, b):
+        for component in (red, green, blue):
             if not 0 <= component <= 255:
                 LOGGER.error("RGB color value %s not in range 0-255.")
                 return
-        storeColor(r, g, b)
+        storeColor(red, green, blue)
         time.sleep(.1)
         chainableRgbLed_pattern(self.port, self.MODE_THIS_LED_ONLY, led)
         time.sleep(.1)

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -42,7 +42,7 @@ class GrovePiChainableRgbLeds:
             if component not in self.COMPONENT_RANGE:
                 raise ValueError(f'RGB color value %s not in range '
                                  f'{self.COMPONENT_RANGE[0]}-'
-                                 f'{self.COMPONENT_RANGE[1]-1}.')
+                                 f'{self.COMPONENT_RANGE[-1]}.')
         storeColor(red, green, blue)
         time.sleep(.1)
         chainableRgbLed_pattern(self.port, self.MODE_THIS_LED_ONLY, led)

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -20,7 +20,7 @@ class GrovePiChainableRgbLeds:
     """A module to set the GrovePi Chainable RGB LEDs."""
 
     MODE_THIS_LED_ONLY = 0
-    COMPONENT_RANGE = 0, 256
+    COMPONENT_RANGE = range(0, 256)
 
     port = None
 

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -1,0 +1,48 @@
+"""
+Class for communicating with the GrovePi ultrasonic ranger.
+
+Here we treat it as a binary sensor.
+"""
+
+import logging
+import time
+
+logging.basicConfig()
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.getLevelName('INFO'))
+try:
+    from GrovePi.Software.Python.grovepi import chainableRgbLed_pattern,\
+        storeColor, chainableRgbLed_init, pinMode
+except ImportError:
+    LOGGER.warning("GrovePi lib unavailable. Using dummy.")
+    from drivers.dummy_grovepi_interface import chainableRgbLed_pattern,\
+        storeColor, chainableRgbLed_init, pinMode
+
+
+class GrovePiChainableRgbLeds:
+    """A module to set the GrovePi Chainable RGB LEDs."""
+
+    MODE_THIS_LED_ONLY = 0
+    port = None
+
+    def setup(self, port, count):
+        """Create a GrovePi Chainable RGB LEDs module."""
+        self.port = int(port)
+        pinMode(port, "OUTPUT")
+        time.sleep(1)
+        chainableRgbLed_init(self.port, count)
+        LOGGER.info("Setting up %s GrovePi Chainable RGB LEDs on port %s", count, port)
+
+    def set_color(self, led, r, g, b):
+        """Set color in RGB, each ranged 0-255"""
+        if self.port is None:
+            raise RuntimeError("Must call setup before setting color.")
+
+        for component in (r, g, b):
+            if not 0 <= component <= 255:
+                LOGGER.error("RGB color value %s not in range 0-255.")
+                return
+        storeColor(r, g, b)
+        time.sleep(.1)
+        chainableRgbLed_pattern(self.port, self.MODE_THIS_LED_ONLY, led)
+        time.sleep(.1)

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -34,7 +34,7 @@ class GrovePiChainableRgbLeds:
                     count, port)
 
     def set_color(self, led, red, green, blue):
-        """Set color in RGB"""
+        """Set color in RGB."""
         if self.port is None:
             raise RuntimeError("Must call setup before setting color.")
 

--- a/rovercode/tests/test_app.py
+++ b/rovercode/tests/test_app.py
@@ -68,38 +68,6 @@ def test_app_on_chainable_led_message(testapp):
     mock_rgb_manager.set_color.assert_called_with(0, 50, 255, 80)
 
 
-def test_app_on_chainable_led_message_bad_id(testapp):
-    """Test an incoming chainable RGB LED message with a bad id."""
-    websocket = MagicMock()
-    mock_rgb_manager = MagicMock()
-    mock_rgb_manager.count = 1
-    testapp.CHAINABLE_RGB_MANAGER = mock_rgb_manager
-    testapp.on_message(websocket, json.dumps({
-        constants.MESSAGE_TYPE: constants.CHAINABLE_RGB_LED_COMMAND,
-        constants.CHAINABLE_RGB_LED_ID_FIELD: 10,
-        constants.CHAINABLE_RGB_LED_RED_VALUE_FIELD: 50,
-        constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD: 255,
-        constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD: 80
-    }))
-    mock_rgb_manager.set_color.assert_not_called()
-
-
-def test_app_on_chainable_led_message_missing_color(testapp):
-    """Test an incoming chainable RGB LED message with a missing color."""
-    websocket = MagicMock()
-    mock_rgb_manager = MagicMock()
-    mock_rgb_manager.count = 10
-    testapp.CHAINABLE_RGB_MANAGER = mock_rgb_manager
-    testapp.on_message(websocket, json.dumps({
-        constants.MESSAGE_TYPE: constants.CHAINABLE_RGB_LED_COMMAND,
-        constants.CHAINABLE_RGB_LED_ID_FIELD: 0,
-        constants.CHAINABLE_RGB_LED_RED_VALUE_FIELD: None,
-        constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD: 255,
-        constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD: 80
-    }))
-    mock_rgb_manager.set_color.assert_not_called()
-
-
 def test_app_on_motor_message(testapp):
     """Test an incoming motor message."""
     websocket = MagicMock()

--- a/rovercode/tests/test_app.py
+++ b/rovercode/tests/test_app.py
@@ -65,7 +65,23 @@ def test_app_on_chainable_led_message(testapp):
         constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD: 255,
         constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD: 80
     }))
-    mock_rgb_manager.set_color.assert_called_with(0, 50, 255, 80)
+    mock_rgb_manager.set_led_color.assert_called_with(0, 50, 255, 80)
+
+
+def test_app_on_chainable_led_message_error_setting_color(testapp):
+    """Test an incoming chainable RGB LED message with a bad id."""
+    websocket = MagicMock()
+    mock_rgb_manager = MagicMock()
+    mock_rgb_manager.set_led_color.side_effect = ValueError("wrong value")
+    testapp.CHAINABLE_RGB_MANAGER = mock_rgb_manager
+    testapp.on_message(websocket, json.dumps({
+        constants.MESSAGE_TYPE: constants.CHAINABLE_RGB_LED_COMMAND,
+        constants.CHAINABLE_RGB_LED_ID_FIELD: 1,
+        constants.CHAINABLE_RGB_LED_RED_VALUE_FIELD: 50,
+        constants.CHAINABLE_RGB_LED_GREEN_VALUE_FIELD: 255,
+        constants.CHAINABLE_RGB_LED_BLUE_VALUE_FIELD: 80
+    }))
+    # Check only that exception is handled.
 
 
 def test_app_on_motor_message(testapp):

--- a/rovercode/tests/test_app.py
+++ b/rovercode/tests/test_app.py
@@ -69,7 +69,7 @@ def test_app_on_chainable_led_message(testapp):
 
 
 def test_app_on_chainable_led_message_bad_id(testapp):
-    """Test an incoming chainable RGB LED message."""
+    """Test an incoming chainable RGB LED message with a bad id."""
     websocket = MagicMock()
     mock_rgb_manager = MagicMock()
     mock_rgb_manager.count = 1
@@ -85,7 +85,7 @@ def test_app_on_chainable_led_message_bad_id(testapp):
 
 
 def test_app_on_chainable_led_message_missing_color(testapp):
-    """Test an incoming chainable RGB LED message."""
+    """Test an incoming chainable RGB LED message with a missing color."""
     websocket = MagicMock()
     mock_rgb_manager = MagicMock()
     mock_rgb_manager.count = 10

--- a/rovercode/tests/test_app.py
+++ b/rovercode/tests/test_app.py
@@ -1,13 +1,15 @@
 """Test the app module."""
 import json
 import os
-import pytest
 from unittest.mock import MagicMock, patch
+import pytest
 
 import constants
 
+
 @pytest.fixture()
 def rover_params():
+    """Rover parameters."""
     params = {
         constants.ROVER_NAME: 'rovy mcroverface',
         constants.ROVER_ID: 42,
@@ -166,7 +168,7 @@ def test_app_main_missing_led_count(testapp, rover_params):
     env_values = {'CLIENT_ID': 'foo',
                   'CLIENT_SECRET': 'bar',
                   'ROVERCODE_WEB_HOST': 'qux'}
-    rover_params[constants.ROVER_CONFIG][constants.NUM_CHAINABLE_RGB_LEDS] = None
+    rover_params[constants.ROVER_CONFIG].pop(constants.NUM_CHAINABLE_RGB_LEDS)
     response = MagicMock()
     response.text = json.dumps({'results': [rover_params]})
     session = MagicMock()
@@ -178,12 +180,13 @@ def test_app_main_missing_led_count(testapp, rover_params):
         with patch.object(testapp, 'OAuth2Session', session_wrapper):
             testapp.run_service(run_forever=False, use_dotenv=False)
 
+
 def test_app_main_missing_led_port(testapp, rover_params):
     """Smoke test that the main function returns with no LED port."""
     env_values = {'CLIENT_ID': 'foo',
                   'CLIENT_SECRET': 'bar',
                   'ROVERCODE_WEB_HOST': 'qux'}
-    rover_params[constants.ROVER_CONFIG][constants.CHAINABLE_RGB_LED_PORT] = None
+    rover_params[constants.ROVER_CONFIG].pop(constants.CHAINABLE_RGB_LED_PORT)
     response = MagicMock()
     response.text = json.dumps({'results': [rover_params]})
     session = MagicMock()
@@ -208,11 +211,11 @@ def test_app_main_motor_exception(testapp, rover_params):
     session.get.return_value = response
     session_wrapper = MagicMock()
     session_wrapper.return_value = session
-    bad_motor_controller = MagicMock()
-    bad_motor_controller.side_effect = Exception('Motors broke')
+    bad_controller = MagicMock()
+    bad_controller.side_effect = Exception('Motors broke')
     with patch.dict(os.environ, env_values):
         with patch.object(testapp, 'OAuth2Session', session_wrapper):
-            with patch.object(testapp, 'MotorController', bad_motor_controller):
+            with patch.object(testapp, 'MotorController', bad_controller):
                 testapp.run_service(run_forever=False, use_dotenv=False)
 
 
@@ -234,4 +237,3 @@ def test_app_main_websocket_exception(testapp, rover_params):
         with patch.object(testapp, 'OAuth2Session', session_wrapper):
             with patch.object(testapp, 'WebSocketApp', bad_websocket):
                 testapp.run_service(run_forever=False, use_dotenv=False)
-

--- a/rovercode/tests/test_chainable_rgb_leds_manager.py
+++ b/rovercode/tests/test_chainable_rgb_leds_manager.py
@@ -8,8 +8,9 @@ from chainable_rgb_leds_manager import ChainableRgbLedsManager
 
 @pytest.fixture
 def driver_mock():
-    """Set up mock of the motor driver."""
+    """Set up mock of the LED driver."""
     driver = MagicMock()
+    driver.COMPONENT_RANGE = range(0, 256)
     return driver
 
 

--- a/rovercode/tests/test_chainable_rgb_leds_manager.py
+++ b/rovercode/tests/test_chainable_rgb_leds_manager.py
@@ -1,0 +1,43 @@
+"""Test the chainable RGB LED manager."""
+
+import pytest
+from mock import MagicMock, call
+
+from chainable_rgb_leds_manager import ChainableRgbLedsManager
+
+
+@pytest.fixture
+def driver_mock():
+    """Set up mock of the motor driver."""
+    driver = MagicMock()
+    return driver
+
+
+def test_chainable_rgb_set_color(driver_mock):
+    """Test setting a color."""
+    motor_controller = ChainableRgbLedsManager(3, 1, driver_mock)
+    motor_controller.set_led_color(0, 1, 2, 3)
+    driver_mock.set_color.assert_called_with(0, 1, 2, 3)
+
+
+def test_chainable_rgb_set_color_bad_led(driver_mock):
+    """Test setting a color with an invalid LED id."""
+    num_leds = 1
+    motor_controller = ChainableRgbLedsManager(3, num_leds, driver_mock)
+    motor_controller.set_led_color(num_leds, 1, 2, 3)
+    driver_mock.set_color.assert_not_called()
+
+
+def test_chainable_rgb_set_color_bad_color(driver_mock):
+    """Test setting a color with an invalid color value."""
+    motor_controller = ChainableRgbLedsManager(3, 1, driver_mock)
+    motor_controller.set_led_color(0, 256, 2, 3)
+    driver_mock.set_color.assert_not_called()
+
+
+def test_chainable_rgb_set_color_all_leds(driver_mock):
+    """Test setting the same color to all LEDs."""
+    motor_controller = ChainableRgbLedsManager(3, 2, driver_mock)
+    motor_controller.set_all_led_colors(1, 2, 3)
+    driver_mock.set_color.assert_has_calls([
+        call(0, 1, 2, 3), call(1, 1, 2, 3)])

--- a/rovercode/tests/test_chainable_rgb_leds_manager.py
+++ b/rovercode/tests/test_chainable_rgb_leds_manager.py
@@ -25,15 +25,15 @@ def test_chainable_rgb_set_color_bad_led(driver_mock):
     """Test setting a color with an invalid LED id."""
     num_leds = 1
     motor_controller = ChainableRgbLedsManager(3, num_leds, driver_mock)
-    motor_controller.set_led_color(num_leds, 1, 2, 3)
-    driver_mock.set_color.assert_not_called()
+    with pytest.raises(ValueError):
+        motor_controller.set_led_color(num_leds, 1, 2, 3)
 
 
 def test_chainable_rgb_set_color_bad_color(driver_mock):
     """Test setting a color with an invalid color value."""
     motor_controller = ChainableRgbLedsManager(3, 1, driver_mock)
-    motor_controller.set_led_color(0, 256, 2, 3)
-    driver_mock.set_color.assert_not_called()
+    with pytest.raises(ValueError):
+        motor_controller.set_led_color(0, 256, 2, 3)
 
 
 def test_chainable_rgb_set_color_all_leds(driver_mock):


### PR DESCRIPTION
This adds support for the GrovePi chainable RGB LEDs.

The Rover config on the server specifies how many are present and on what port.

They are initially set to a status color on boot, but then can be set individually over the Websocket protocol.

I shuffled somethings around in the start-up sequence to put the LED initialization as early as possible. Then, if there are any failures after that, we set an error color. Since we need to connect to the server to know on what port the LEDs are connected, WiFi and credential issues cannot show an error color.