### PR TITLE
Increase GrovePi loop polling rate

### DIFF
--- a/rovercode/app.py
+++ b/rovercode/app.py
@@ -64,7 +64,7 @@ def grovepi_thread_loop(ws_connection, binary_sensors, run_once_only=False):
             constants.UNIT_FIELD: constants.SENSOR_UNIT_ACTIVE_HIGH
         }
         for sensor in binary_sensors:
-            time.sleep(0.2)
+            time.sleep(0.05)
             sensor_message[constants.SENSOR_ID_FIELD] = sensor.name
             changed_value = sensor.get_change()
             if changed_value is not None:
@@ -72,7 +72,6 @@ def grovepi_thread_loop(ws_connection, binary_sensors, run_once_only=False):
                 ws_connection.send(json.dumps(sensor_message))
         if run_once_only:
             break
-        time.sleep(0.2)  # pragma: no cover
 
 
 def on_message(_, raw_message):

--- a/rovercode/drivers/grovepi_chainable_rgb_leds.py
+++ b/rovercode/drivers/grovepi_chainable_rgb_leds.py
@@ -44,6 +44,5 @@ class GrovePiChainableRgbLeds:
                                  f'{self.COMPONENT_RANGE[0]}-'
                                  f'{self.COMPONENT_RANGE[-1]}.')
         storeColor(red, green, blue)
-        time.sleep(.1)
+        time.sleep(.05)
         chainableRgbLed_pattern(self.port, self.MODE_THIS_LED_ONLY, led)
-        time.sleep(.1)


### PR DESCRIPTION
This increases the GrovePi loop rate by about 6x.

I tested out the changes on a Rover, and things seems to still work fine. The sensor indicators had a much more responsive feel at this polling rate.